### PR TITLE
add carat to pragma version

### DIFF
--- a/src/lib/ConsiderationErrors.sol
+++ b/src/lib/ConsiderationErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 import { Side } from "./ConsiderationEnums.sol";
 


### PR DESCRIPTION
to help use these libs in repos that are building with newer solidity versions